### PR TITLE
Update .gitmodules to pull release 1.8.1 instead of current bleeding edge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "googletest"]
 	path = googletest
-	url = git@github.com:abseil/googletest.git
+	url = https://github.com/abseil/googletest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "googletest"]
 	path = googletest
 	url = https://github.com/abseil/googletest.git
+	branch = release-1.8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 #matrix:
 
 before_install:
-echo "$TRAVIS_PULL_REQUEST"
+  - echo "$TRAVIS_PULL_REQUEST"
 
 install:
   # Install a supported cmake version (>= 3.10)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: cpp
+sudo: false
+
+branches:
+  only:
+    - master
+
+#matrix:
+
+#before_install:
+
+#install:
+
+script:
+  - mkdir build
+  - cd build
+  - cmake ..
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,20 @@ branches:
 
 #matrix:
 
-#before_install:
+before_install:
+echo "$TRAVIS_PULL_REQUEST"
 
-#install:
+install:
+  # Install a supported cmake version (>= 3.10)
+  - |
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      curl -o miniconda.sh  https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda install -y -c conda-forge cmake
 
 script:
   - mkdir build


### PR DESCRIPTION
This fixes the OSX build error in PR #12.

Based on the test run at PR #21, I expect that if this is merged and pulled in to @SgStapleton's changes at PR #12, the Travis build will succeed.